### PR TITLE
Callbacks on registration of parent and child controllers

### DIFF
--- a/packages/@stimulus/core/src/children_map.ts
+++ b/packages/@stimulus/core/src/children_map.ts
@@ -1,6 +1,5 @@
 import { Controller } from "./controller";
 import { Scope } from "./scope";
-import { camelize } from "./string_helpers";
 
 export class ChildrenMap {
     readonly scope: Scope
@@ -11,8 +10,7 @@ export class ChildrenMap {
         this.childrenByName = new Map
     }
 
-    addChild(controller: Controller) {
-        const name = camelize(controller.identifier)
+    addChild(name: string, controller: Controller) {
         if(!this.childrenByName.has(name)) {
             this.childrenByName.set(name, [])
         }

--- a/packages/@stimulus/core/src/context.ts
+++ b/packages/@stimulus/core/src/context.ts
@@ -8,6 +8,8 @@ import { Schema } from "./schema"
 import { Scope } from "./scope"
 import { ValueObserver } from "./value_observer"
 import { ParentChildConnector } from "./parent_child_connector";
+import { withControllerRegistrationCallbacks } from "./controller_callbacks";
+import {camelize, capitalize} from "./string_helpers";
 
 export class Context implements ErrorHandler {
   readonly module: Module
@@ -54,6 +56,18 @@ export class Context implements ErrorHandler {
     this.valueObserver.stop()
     this.bindingObserver.stop()
     this.parentChildConnector.stop()
+  }
+
+  registerChild(childController: Controller) {
+    const childName = camelize(childController.identifier)
+    withControllerRegistrationCallbacks(this.controller,
+        `${capitalize(childName)}ChildRegistration`,
+        childController,
+        () => { this.scope.children.addChild(childName, childController) })
+    withControllerRegistrationCallbacks(childController,
+        'ParentRegistration',
+        this.controller,
+        () => childController.parent = this.controller)
   }
 
   get application(): Application {

--- a/packages/@stimulus/core/src/controller.ts
+++ b/packages/@stimulus/core/src/controller.ts
@@ -65,8 +65,7 @@ export class Controller {
     if (controller &&
         this.identifier === event.detail.parentIdentifier &&
         this.context.module.relationships.childIdentifiers.includes(controller.identifier)) {
-      this.children.addChild(controller)
-      controller.parent = this
+      this.context.registerChild(controller)
     }
   }
 

--- a/packages/@stimulus/core/src/controller_callbacks.ts
+++ b/packages/@stimulus/core/src/controller_callbacks.ts
@@ -1,0 +1,14 @@
+import { Controller } from "./controller";
+
+export function withControllerRegistrationCallbacks(controller: Controller, name: String, registeredController: Controller, func: () => void) {
+  conditionalCall(controller, `before${name}`, registeredController)
+  func()
+  conditionalCall(controller, `after${name}`, registeredController)
+}
+
+function conditionalCall(controller: Controller, callback: string, registeredController: Controller) {
+  if (callback in controller) {
+    // @ts-ignore
+    controller[callback](registeredController)
+  }
+}

--- a/packages/@stimulus/core/src/tests/controllers/parent_controller.ts
+++ b/packages/@stimulus/core/src/tests/controllers/parent_controller.ts
@@ -12,12 +12,33 @@ export class ItemsController extends BaseItemsController {
 
     statusBoxChildren!: StatusBoxController[]
     statusBoxChild!: StatusBoxController
+
+    beforeItemChildRegistration(controller: ItemController) {
+        controller.parentBeforeCallbackInvoked = true
+    }
+
+    afterItemChildRegistration(controller: ItemController) {
+        controller.parentAfterCallbackInvoked = true
+    }
 }
 
 export class ItemController extends Controller {
     static parent = "items"
 
+    parentBeforeCallbackInvoked = false
+    parentAfterCallbackInvoked = false
+    beforeParameter?: Controller
+    afterParameter?: Controller
+
     parent!: ItemsController
+
+    beforeParentRegistration(controller: Controller) {
+        this.beforeParameter = controller
+    }
+
+    afterParentRegistration(controller: Controller) {
+        this.afterParameter = controller
+    }
 }
 
 class BaseStatusBoxController extends Controller {

--- a/packages/@stimulus/core/src/tests/modules/parent_child_tests.ts
+++ b/packages/@stimulus/core/src/tests/modules/parent_child_tests.ts
@@ -1,5 +1,6 @@
 import { ControllerTestCase } from "../cases/controller_test_case"
 import {ItemsController, ItemController, StatusBoxController} from "../controllers/parent_controller"
+import {Controller} from "../../controller";
 
 export default class ParentChildTests extends ControllerTestCase() {
   setupApplication() {
@@ -28,6 +29,10 @@ export default class ParentChildTests extends ControllerTestCase() {
     } else {
       throw new Error("no status box controller connected")
     }
+  }
+
+  get childControllers(): Controller[] {
+    return this.controllers.filter(controller => controller.identifier != 'items') as Controller[]
   }
 
   fixtureHTML = `
@@ -75,8 +80,7 @@ export default class ParentChildTests extends ControllerTestCase() {
   }
 
   "test each child controller assigned its parent"() {
-    const childControllers = this.childItemControllers.concat([this.childStatusBoxController])
-    childControllers.forEach(childController => {
+    this.childControllers.forEach(childController => {
       this.assert.equal(this.parentController, childController.parent)
     })
   }

--- a/packages/@stimulus/core/src/tests/modules/parent_child_tests.ts
+++ b/packages/@stimulus/core/src/tests/modules/parent_child_tests.ts
@@ -84,4 +84,30 @@ export default class ParentChildTests extends ControllerTestCase() {
       this.assert.equal(this.parentController, childController.parent)
     })
   }
+
+  "test before callback invoked for parent registration with parent as param"() {
+    const parent = this.parentController
+    this.childItemControllers.forEach(controller => {
+      this.assert.equal(controller.beforeParameter, parent)
+    })
+  }
+
+  "test after callback invoked for parent registration with parent as param"() {
+    const parent = this.parentController
+    this.childItemControllers.forEach(controller => {
+      this.assert.equal(controller.afterParameter, parent)
+    })
+  }
+
+  "test before callback invoked for child registration"() {
+    this.childItemControllers.forEach(controller => {
+      this.assert.ok(controller.parentBeforeCallbackInvoked)
+    })
+  }
+
+  "test after callback invoked for item child"() {
+    this.childItemControllers.forEach(controller => {
+      this.assert.ok(controller.parentAfterCallbackInvoked)
+    })
+  }
 }


### PR DESCRIPTION
Callbacks for children are by name (for example `beforeItemChildRegistration`) while parent callbacks are static (`beforeParentRegistration`).